### PR TITLE
Improve support for type aliases.

### DIFF
--- a/decl/decl.go
+++ b/decl/decl.go
@@ -230,6 +230,9 @@ func writeSpec(buf *bytes.Buffer, x ast.Spec) {
 	case *ast.TypeSpec:
 		buf.WriteString(x.Name.Name)
 		buf.WriteString(" as ")
+		if x.Assign.IsValid() {
+			buf.WriteString("alias of ")
+		}
 		writeExpr(buf, x.Type)
 
 	case *ast.ImportSpec:

--- a/decl/decl_test.go
+++ b/decl/decl_test.go
@@ -119,6 +119,15 @@ func TestGoToEnglish(t *testing.T) {
 			"func Foo(x int) string",
 			"function Foo taking x int and returning string",
 		},
+
+		{
+			"type T1 T2",
+			"declare type T1 as T2",
+		},
+		{
+			"type T1 = T2",
+			"declare type T1 as alias of T2",
+		},
 	}
 	for _, tc := range tests {
 		got, err := decl.GoToEnglish(tc.in)

--- a/examples.go
+++ b/examples.go
@@ -12,6 +12,7 @@ var examples = []string{
 	"var x func() *[5]*func() rune",
 	"var x, y int = 1, 2",
 	"var x = (2+5)/3.0 + 4",
+	"type T1 = T2",
 
 	// TODO: Add more fun and interesting example inputs.
 	//       See decl tests for inspiration.


### PR DESCRIPTION
Differentiate them from regular type declarations.

Add an example.

See this live at https://godecl.org/?q=type+T1+%3D+T2.

~CI will fail because Travis hasn't been updated for 1.9 yet, it will pass once https://github.com/travis-ci/travis-build/pull/1148 is merged.~ **Edit:** CI is passing.